### PR TITLE
bugfix/failing app state deletion

### DIFF
--- a/src/Messenger.ts
+++ b/src/Messenger.ts
@@ -17,7 +17,7 @@ export interface CrossDocumentMessageResponse<T> {
 
 export interface AppBridgeResponse<T> {
     success: boolean;
-    data: T;
+    data?: T;
 }
 
 export default class Messenger {
@@ -41,7 +41,7 @@ export default class Messenger {
                     return;
                 }
 
-                response.success && response.data
+                response.success
                     ? resolve({
                           success: response.success,
                           data: response.data,


### PR DESCRIPTION
If we delete the app state, the response doesn't contain data, because the property data is opitonal in CrossDocumentMessageResponse. Therefore, we reject even if deleting the app state was actually successful. In production, it fails silently, but locally, I got an error message.

I know, this is not the final solution, because with this change, we again (at least partially) need to check if data exists when calling AppBridge functions, but I think these problems will not go away unless we (or someone else) does a bigger refactoring with introducing more layers of abstraction. Therefore, I think this change (combined with https://github.com/Frontify/figma-platform-app/pull/4) is consequent for the stage we are now.